### PR TITLE
Fix bluetooth for HiFiBerry DAC/DAC+

### DIFF
--- a/airplay_config.sh
+++ b/airplay_config.sh
@@ -112,7 +112,6 @@ ao =
 
 // Static latency settings are deprecated and the settings have been removed.
 EOT
-
 elif [ $SoundCard = "0" ]
 then
 	cat <<EOT > /etc/shairport-sync.conf

--- a/airplay_config.sh
+++ b/airplay_config.sh
@@ -78,7 +78,7 @@ sessioncontrol =
 // These are parameters for the "alsa" audio back end, the only back end that supports synchronised audio.
 alsa =
 {
-output_device = "hw:1,0"; // the name of the alsa output device. Use "alsamixer" or "aplay" to find out the names of devices, mixers, etc.
+output_device = "hw:0,0"; // the name of the alsa output device. Use "alsamixer" or "aplay" to find out the names of devices, mixers, etc.
 //  mixer_control_name = "PCM"; // the name of the mixer to use to adjust output volume. If not specified, volume in adjusted in software.
 //  mixer_device = "default"; // the mixer_device default is whatever the output_device is. Normally you wouldn't have to use this.
 //  audio_backend_latency_offset = 0; // Set this offset to compensate for a fixed delay in the audio back end. E.g. if the output device delays by 100 ms, set this to -4410.

--- a/sound_card_install.sh
+++ b/sound_card_install.sh
@@ -94,7 +94,6 @@ dtoverlay=hifiberry-dac
 # Enable HiFiberry DAC Standard/Pro
 #dtoverlay=hifiberry-dacplus
 
-
 # Enable HiFiberry Digi
 #dtoverlay=hifiberry-digi
 
@@ -116,6 +115,7 @@ dtoverlay=hifiberry-dac
 # Enable JustBoom Digi Cards
 #dtoverlay=justboom-digi
 EOT
+sed -i '56 s/^/#/' /boot/config.txt
 elif [ $SoundCard = "2" ]
 then
 sudo cat <<EOT >> /etc/modprobe.d/alsa-base.conf
@@ -150,7 +150,6 @@ sudo cat <<EOT >>/boot/config.txt
 # Enable HiFiberry DAC Standard/Pro
 dtoverlay=hifiberry-dacplus
 
-
 # Enable HiFiberry Digi
 #dtoverlay=hifiberry-digi
 
@@ -172,6 +171,7 @@ dtoverlay=hifiberry-dacplus
 # Enable JustBoom Digi Cards
 #dtoverlay=justboom-digi
 EOT
+sed -i '56 s/^/#/' /boot/config.txt
 elif [ $SoundCard = "3" ]
 then
 sudo cat <<EOT >> /etc/modprobe.d/alsa-base.conf

--- a/sound_card_install.sh
+++ b/sound_card_install.sh
@@ -27,7 +27,7 @@ ctl.!default {
     card 0
 }
 EOT
-sudo cat <<EOT >>/boot/config.txt
+sudo cat <<EOT >> /boot/config.txt
 # Enable HiFiberry Amp
 #dtoverlay=hifiberry-amp
 
@@ -59,7 +59,6 @@ sudo cat <<EOT >>/boot/config.txt
 # Enable JustBoom Digi Cards
 #dtoverlay=justboom-digi
 EOT
-
 elif [ $SoundCard = "1" ]
 then
 sudo cat <<EOT >> /etc/modprobe.d/alsa-base.conf
@@ -115,7 +114,7 @@ dtoverlay=hifiberry-dac
 # Enable JustBoom Digi Cards
 #dtoverlay=justboom-digi
 EOT
-sed -i '56 s/^/#/' /boot/config.txt
+sed -i '56 s/^/#/' /boot/config.txt # fixes problem with onboard sound card
 elif [ $SoundCard = "2" ]
 then
 sudo cat <<EOT >> /etc/modprobe.d/alsa-base.conf
@@ -228,6 +227,7 @@ dtoverlay=hifiberry-digi
 # Enable JustBoom Digi Cards
 #dtoverlay=justboom-digi
 EOT
+sed -i '56 s/^/#/' /boot/config.txt
 elif [ $SoundCard = "4" ]
 then
 sudo cat <<EOT >> /etc/modprobe.d/alsa-base.conf
@@ -284,6 +284,7 @@ dtoverlay=hifiberry-amp
 # Enable JustBoom Digi Cards
 #dtoverlay=justboom-digi
 EOT
+sed -i '56 s/^/#/' /boot/config.txt
 elif [ $SoundCard = "5" ]
 then
 sudo cat <<EOT >> /etc/modprobe.d/alsa-base.conf
@@ -340,6 +341,7 @@ dtoverlay=iqaudio-dac
 # Enable JustBoom Digi Cards
 #dtoverlay=justboom-digi
 EOT
+sed -i '56 s/^/#/' /boot/config.txt
 elif [ $SoundCard = "6" ]
 then
 sudo cat <<EOT >> /etc/modprobe.d/alsa-base.conf
@@ -396,6 +398,7 @@ dtoverlay=iqaudio-dacplus
 # Enable JustBoom Digi Cards
 #dtoverlay=justboom-digi
 EOT
+sed -i '56 s/^/#/' /boot/config.txt
 elif [ $SoundCard = "7" ]
 then
 sudo cat <<EOT >> /etc/modprobe.d/alsa-base.conf
@@ -452,6 +455,7 @@ dtoverlay=iqaudio-dacplus,unmute_amp
 # Enable JustBoom Digi Cards
 #dtoverlay=justboom-digi
 EOT
+sed -i '56 s/^/#/' /boot/config.txt
 elif [ $SoundCard = "8" ]
 then
 sudo cat <<EOT >> /etc/modprobe.d/alsa-base.conf
@@ -510,6 +514,7 @@ dtoverlay=iqaudio-digi-wm8804-audio
 
 
 EOT
+sed -i '56 s/^/#/' /boot/config.txt
 elif [ $SoundCard = "9" ]
 then
 sudo cat <<EOT >> /etc/modprobe.d/alsa-base.conf
@@ -566,6 +571,7 @@ sudo cat <<EOT >>/boot/config.txt
 # Enable JustBoom Digi Cards
 #dtoverlay=justboom-digi
 EOT
+sed -i '56 s/^/#/' /boot/config.txt
 elif [ $SoundCard = "10" ]
 then
 sudo cat <<EOT >> /etc/modprobe.d/alsa-base.conf
@@ -622,6 +628,7 @@ dtoverlay=justboom-dac
 # Enable JustBoom Digi Cards
 #dtoverlay=justboom-digi
 EOT
+sed -i '56 s/^/#/' /boot/config.txt
 elif [ $SoundCard = "11" ]
 then
 sudo cat <<EOT >> /etc/modprobe.d/alsa-base.conf
@@ -656,7 +663,6 @@ sudo cat <<EOT >>/boot/config.txt
 # Enable HiFiberry DAC Standard/Pro
 #dtoverlay=hifiberry-dacplus
 
-
 # Enable HiFiberry Digi
 #dtoverlay=hifiberry-digi
 
@@ -678,5 +684,6 @@ sudo cat <<EOT >>/boot/config.txt
 # Enable JustBoom Digi Cards
 dtoverlay=justboom-digi
 EOT
+sed -i '56 s/^/#/' /boot/config.txt
 fi
 exit 0


### PR DESCRIPTION
There was a problem with the /boot/config.txt file that was causing audio from A2DP to go through the aux port instead of the sound card. I fixed it by using the sed command (which I tested first) to comment out the line that says "dtparam=audio=on" in config.txt in sound_card_install.sh. It should work now, but existing users will have to either rerun the script or make the change themselves.