### PR TITLE
Adding libtool install.

### DIFF
--- a/airplay_config.sh
+++ b/airplay_config.sh
@@ -78,7 +78,7 @@ sessioncontrol =
 // These are parameters for the "alsa" audio back end, the only back end that supports synchronised audio.
 alsa =
 {
-output_device = "hw:0,0"; // the name of the alsa output device. Use "alsamixer" or "aplay" to find out the names of devices, mixers, etc.
+// output_device = "hw:0,0"; // the name of the alsa output device. Use "alsamixer" or "aplay" to find out the names of devices, mixers, etc.
 //  mixer_control_name = "PCM"; // the name of the mixer to use to adjust output volume. If not specified, volume in adjusted in software.
 //  mixer_device = "default"; // the mixer_device default is whatever the output_device is. Normally you wouldn't have to use this.
 //  audio_backend_latency_offset = 0; // Set this offset to compensate for a fixed delay in the audio back end. E.g. if the output device delays by 100 ms, set this to -4410.
@@ -176,7 +176,7 @@ sessioncontrol =
 // These are parameters for the "alsa" audio back end, the only back end that supports synchronised audio.
 alsa =
 {
-output_device = "hw:0,0"; // the name of the alsa output device. Use "alsamixer" or "aplay" to find out the names of devices, mixers, etc.
+//output_device = "hw:0,0"; // the name of the alsa output device. Use "alsamixer" or "aplay" to find out the names of devices, mixers, etc.
 //  mixer_control_name = "PCM"; // the name of the mixer to use to adjust output volume. If not specified, volume in adjusted in software.
 //  mixer_device = "default"; // the mixer_device default is whatever the output_device is. Normally you wouldn't have to use this.
 //  audio_backend_latency_offset = 0; // Set this offset to compensate for a fixed delay in the audio back end. E.g. if the output device delays by 100 ms, set this to -4410.

--- a/bt_pa_config.sh
+++ b/bt_pa_config.sh
@@ -184,7 +184,7 @@ make
 sudo make install
 cd ~
 cd pulseaudio
-./bootstrap
+./bootstrap.sh
 make
 make install
 ldconfig

--- a/bt_pa_config.sh
+++ b/bt_pa_config.sh
@@ -149,6 +149,7 @@ EOT
 mkdir /etc/pulsebackup
 cp /etc/pulse/* /etc/pulsebackup/
 git clone --branch v6.0 https://github.com/pulseaudio/pulseaudio
+apt-get install libtool
 apt-get install intltool
 apt-get install libsndfile-dev
 apt-get install libcap-dev

--- a/bt_pa_config.sh
+++ b/bt_pa_config.sh
@@ -148,6 +148,7 @@ EOT
 # BT FIX
 mkdir /etc/pulsebackup
 cp /etc/pulse/* /etc/pulsebackup/
+cd ~
 git clone --branch v6.0 https://github.com/pulseaudio/pulseaudio
 apt-get install libtool
 apt-get install intltool
@@ -165,12 +166,30 @@ apt-get install libspeexdsp-dev
 apt-get install libssl-dev
 apt-get install libtdb-dev
 apt-get install libbluetooth-dev
+apt-get install intltool -y
+cd ~
+git clone https://github.com/json-c/json-c.git
+cd json-c
+sh autogen.sh
+./configure 
+make
+make install
+cd ~
+apt install autoconf autogen automake build-essential libasound2-dev libflac-dev libogg-dev libtool libvorbis-dev pkg-config python -y
+git clone git://github.com/erikd/libsndfile.git
+cd libsndfile
+./autogen.sh
+./configure --enable-werror
+make
+sudo make install
+cd ~
 cd pulseaudio
-./bootstrap.sh
+./bootstrap
 make
 make install
 ldconfig
 cp /etc/pulsebackup/* /etc/pulse
+sed -i "s/DAEMON=.*/DAEMON=/usr/local/bin/pulseaudio/" /etc/init.d/pulseaudio
 
 sleep 5
 

--- a/bt_pa_config.sh
+++ b/bt_pa_config.sh
@@ -154,6 +154,17 @@ apt-get install intltool
 apt-get install libsndfile-dev
 apt-get install libcap-dev
 apt-get install libjson0-dev
+apt-get install libasound2-dev
+apt-get install libavahi-client-dev
+apt-get install libbluetooth-dev
+apt-get install libglib2.0-dev
+apt-get install liborc-0.4-dev
+apt-get install libsamplerate0-dev
+apt-get install libsbc-dev
+apt-get install libspeexdsp-dev
+apt-get install libssl-dev
+apt-get install libtdb-dev
+apt-get install libbluetooth-dev
 cd pulseaudio
 ./bootstrap.sh
 make

--- a/init.d/pulseaudio
+++ b/init.d/pulseaudio
@@ -12,7 +12,7 @@
 #                    the PulseAudio sound server.
 ### END INIT INFO
 
-DAEMON=/usr/bin/pulseaudio
+DAEMON=/usr/local/bin/pulseaudio
 PIDDIR=/var/run/pulse
 PIDFILE=$PIDDIR/pid
 DAEMONUSER=pulse


### PR DESCRIPTION
libtool isn't installed by default and without it, the install of the BT FIX at the end of bt_pa_config.sh fails (quietly).